### PR TITLE
UI fixes and polish

### DIFF
--- a/lib/widgets/board_widget.dart
+++ b/lib/widgets/board_widget.dart
@@ -211,7 +211,6 @@ class _GameBoardState extends State<GameBoard> {
                 return Positioned(
                   left: piece.position!.col * widget.cellSize,
                   top: piece.position!.row * widget.cellSize,
-
                   child: piece,
                 );
               }),

--- a/lib/widgets/piece_widget.dart
+++ b/lib/widgets/piece_widget.dart
@@ -55,7 +55,7 @@ class PieceWidget extends StatelessWidget {
           child: _buildPieceContent(),
         ),
         childWhenDragging: Opacity(
-          opacity: 0.5,
+          opacity: 0.3,
           child: _buildPieceContent(),
         ),
         child: _buildPieceContent(),

--- a/lib/widgets/pieces_interface_widget.dart
+++ b/lib/widgets/pieces_interface_widget.dart
@@ -4,6 +4,7 @@ import 'piece_widget.dart';
 
 class PiecesInterface extends StatefulWidget {
   final List<ChockABlockPiece> pieces;
+  final List<PieceWidget> placedPieces;
   final double cellSize;
   final ChockABlockPiece? draggingPiece;
   final Function(ChockABlockPiece) onDragStarted;
@@ -12,11 +13,11 @@ class PiecesInterface extends StatefulWidget {
   const PiecesInterface({
     super.key,
     required this.pieces,
+    required this.placedPieces,
     required this.cellSize,
     required this.draggingPiece,
     required this.onDragStarted,
     required this.onDragEnded,
-    required List<PieceWidget> placedPieces,
   });
 
   @override
@@ -24,6 +25,15 @@ class PiecesInterface extends StatefulWidget {
 }
 
 class _PiecesInterfaceState extends State<PiecesInterface> {
+  // Store initial pieces to maintain consistent container size
+  late final List<ChockABlockPiece> allPieces;
+
+  @override
+  void initState() {
+    super.initState();
+    allPieces = List.from(widget.pieces);
+  }
+
   void onPieceTapped(ChockABlockPiece piece) {
     setState(() {
       piece.rotateRight();
@@ -36,6 +46,20 @@ class _PiecesInterfaceState extends State<PiecesInterface> {
     });
   }
 
+  int _pieceWidthDefiner(ChockABlockPiece piece) {
+    if (piece.id == "clifford" ||
+        piece.id == "betty" ||
+        piece.id == "ray") {
+      return 4;
+    }
+    else if (piece.id == "billie") {
+      return 2;
+    }
+    else {
+      return 3;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -43,56 +67,68 @@ class _PiecesInterfaceState extends State<PiecesInterface> {
         color: Colors.white,
         borderRadius: BorderRadius.circular(8),
       ),
-      padding: const EdgeInsets.all(16),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: widget.pieces.map((piece) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: GestureDetector(
-                onTap: () => onPieceTapped(piece),
-                onLongPress: () => onPieceLongPressed(piece),
-                child: Draggable<ChockABlockPiece>(
-                  data: piece,
-                  feedback: Opacity(
-                    opacity: 0.5,
-                    child: Transform.translate(
-                      offset: Offset(
-                        -widget.cellSize * piece.pattern[0].length / 2,
-                        -widget.cellSize * piece.pattern.length / 2,
-                      ),
-                      child: PieceWidget(
-                        piece: piece,
-                        position: piece.position,
-                        cellSize: widget.cellSize * 2,
-                        onTap: () {},
-                      ),
+      padding: const EdgeInsets.symmetric(horizontal: 2.5, vertical: 6.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: allPieces.map((piece) {
+          final isAvailable = widget.pieces.any((p) => p.id == piece.id);
+          final isPlaced = widget.placedPieces.any((p) => p.piece.id == piece.id);
+
+          return Container(
+            width: _pieceWidthDefiner(piece) * widget.cellSize,
+            height: 4 * widget.cellSize * 1.25,
+            alignment: Alignment.center,
+            child: !isAvailable || isPlaced
+                ? Opacity(
+                opacity: 0.35,
+                child: PieceWidget(
+                piece: piece,
+                position: null,
+                cellSize: widget.cellSize,
+                onTap: () => {},
+              ),
+            )
+            : GestureDetector(
+              onTap: () => onPieceTapped(piece),
+              onLongPress: () => onPieceLongPressed(piece),
+              child: Draggable<ChockABlockPiece>(
+                data: piece,
+                feedback: Opacity(
+                  opacity: 0.5,
+                  child: Transform.translate(
+                    offset: Offset(
+                      -widget.cellSize * piece.pattern[0].length / 2,
+                      -widget.cellSize * piece.pattern.length / 2,
                     ),
-                  ),
-                  childWhenDragging: Opacity(
-                    opacity: 0.5,
                     child: PieceWidget(
                       piece: piece,
-                      position: null,
-                      cellSize: widget.cellSize,
+                      position: piece.position,
+                      cellSize: widget.cellSize * 2,
                       onTap: () {},
                     ),
                   ),
-                  onDragStarted: () => widget.onDragStarted(piece),
-                  onDragEnd: (_) => widget.onDragEnded(piece),
+                ),
+                childWhenDragging: Opacity(
+                  opacity: 0.5,
                   child: PieceWidget(
                     piece: piece,
                     position: null,
                     cellSize: widget.cellSize,
-                    onTap: () => onPieceTapped(piece),
+                    onTap: () {},
                   ),
                 ),
+                onDragStarted: () => widget.onDragStarted(piece),
+                onDragEnd: (_) => widget.onDragEnded(piece),
+                child: PieceWidget(
+                  piece: piece,
+                  position: null,
+                  cellSize: widget.cellSize,
+                  onTap: () => onPieceTapped(piece),
+                ),
               ),
-            );
-          }).toList(),
-        ),
+            ),
+          );
+        }).toList(),
       ),
     );
   }


### PR DESCRIPTION
- Make it so pieces bar does not change size when pieces are rotated or placed
- Make it so pieces' distance from one another is constant so when they are rotated they don't push their neighbours over
- Make it so when a piece is placed it's position in the pieces bar is still identifiable
- Make it so when a piece is returned from the board it returns to its original position in the piece bar